### PR TITLE
Deploy doc to gh-pages using Github Actions

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -1,0 +1,32 @@
+name: Deploy doc to gh-pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Use OCaml 4.14.x
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.14.x
+          dune-cache: true
+
+      - run: opam install dune
+
+      - name: Build documentation
+        run: opam exec -- dune build @doc
+
+      - name: Deploy odoc to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ github.token }}
+          publish_dir: _build/default/_doc/_html
+          destination_dir:
+          enable_jekyll: false

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Richmdx
+
+Promotable mld files with rich content.
+
+See the source code in [pages/](pages/) and the result on [gh-pages](https://jonludlam.github.io/richmdx).

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Promotable mld files with rich content.
 
-See the source code in [pages/](pages/) and the result on [gh-pages](https://jonludlam.github.io/richmdx).
+See the source code in [pages/](pages/) and the result on [gh-pages](https://jonludlam.github.io/richmdx/richmdx).


### PR DESCRIPTION
Not using `ocaml/setup-ocaml/deploy-doc` because it doesn't work well with duniverses. The final deploy step is the same but the `opam install` steps are skipped.

The result on my fork should appear at https://julow.github.io/richmdx/richmdx/